### PR TITLE
[#3] Fix date parsing on Android Hermes engine

### DIFF
--- a/lib/ntp-client.js
+++ b/lib/ntp-client.js
@@ -104,8 +104,8 @@
 
                 var milliseconds = (intpart * 1000 + (fractpart * 1000) / 0x100000000);
 
-                // **UTC** time
-                var date = new Date("Jan 01 1900 GMT");
+                var startUTCMilliseconds = Date.UTC(1900, 0, 1); // Jan 01 1900 – initial NTP date
+                var date = new Date(startUTCMilliseconds);
                 date.setUTCMilliseconds(date.getUTCMilliseconds() + milliseconds);
 
                 callback(null, date);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-ntp-client",
     "description": "React Native compatible implementation of the NTP Client Protocol",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "homepage": "https://github.com/artem-russkikh/react-native-ntp-client",
     "author": {
         "name": "Clément Bourgeois",


### PR DESCRIPTION
Closes #3

Due to returning `NaN` when parsing Date:
- https://github.com/facebook/hermes/issues/136
- https://github.com/facebook/hermes/issues/84